### PR TITLE
Config prompt

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -46,6 +46,11 @@ Table of Contents
       2. [Upgrade the Database](maintenance.md#2-upgrade-the-database)
       3. [Upgrade libIsidore and the Isidore Command Prompt](maintenance.md#3-upgrade-libisidore-and-the-isidore-command-prompt)
       4. [Import the Current Configuration](maintenance.md#4-import-the-current-configuration)
+9. [Configuring the Isidore Installation](config.md)
+   1. [Overview](config.md#1-overview)
+   2. [Querying Information About the Installation](config.md#2-querying-information-about-the-installation)
+      1. [Database Connection Information](config.md#1-database-connection-information)
+      2. [Version Information](config.md#2-version-information)
 
 Appendecies
 -----------

--- a/doc/config.md
+++ b/doc/config.md
@@ -1,0 +1,52 @@
+# 9. Configuring the Isidore Installation
+
+1. [Overview](#1-overview)
+2. [Querying Information About the Installation](#2-querying-information-about-the-installation)
+   1. [Database Connection Information](#1-database-connection-information)
+   2. [Version Information](#2-version-information)
+
+## 1. Overview
+
+There are various parameters of the global Isidore that can be configured from
+the command line. These paramenters are modified via the `config` subprompt.
+From the config subprompt, the parameters can be configured, queried, and
+unconfigured using the `set`, `show`, and `unset` commands respectively. One
+can think of working with these parameters as akin to interacting with
+[variables](variables.md) that affect the whole Isidore installation.
+
+## 2. Querying Information About the Installation
+
+### 1. Database Connection Information
+
+Information about the SQL database connection can be displayed by issuing the
+`show connection` command from the config subprompt. It displays the following
+information:
+
+| Field    | Description                                 |
+| -------- | ------------------------------------------- |
+| database | The name of the installation's SQL database |
+| host     | The SQL server                              |
+| user     | The SQL user                                |
+
+### 2. Version Information
+
+Information about the Isidore version can be displayed by issuing the `show
+version` command from the config subprompt. It displays the following
+information:
+
+| Field                          | Description                                          |
+| ------------------------------ | ---------------------------------------------------- |
+| Isidore Command Prompt version | The version of the Isidore comand prompt binary      |
+| libIsidore version             | The version of the underlying Isidore Python library |
+| Isidore database version       | The version of the Isidore SQL database              |
+
+In order for the Isidore installation to be functional, the command prompt,
+library, and database versions MUST be of the same major version. For the minor version and patch release, the following constraint MUST be satisfied:
+
+command prompt >= library >= database
+
+Note that the library and database versions SHOULD be the same as the internal
+database structure is not considered part of the public API. A library version
+with a minor version or patch release number greater than the database version
+may or may not work depending on the specific combination.
+

--- a/lib/src/isidore/libIsidore.py
+++ b/lib/src/isidore/libIsidore.py
@@ -32,6 +32,9 @@ class Isidore:
 
     _conn = None
     _version = '0.1.6-dev0'
+    _db_user = None
+    _db_host = None
+    _db_name = None
 
     # Connects to a MySQL database and creates a new Isidore object to interact
     # with it.
@@ -40,6 +43,9 @@ class Isidore:
     # @param host       The MySQL server to connect to
     # @param database   The name of the database to use
     def __init__(self, user, password, host, database):
+        self._db_user = user
+        self._db_host = host
+        self._db_name = database
         self._conn = mysql.connector.connect(
                 user = user,
                 password = password,
@@ -137,6 +143,21 @@ class Isidore:
         row = cursor.fetchone()
         cursor.close()
         return row[0]
+
+    # Gets the Isidore MySQL database user account name
+    # @return       The Isidore database user account name
+    def getDatabaseUser(self):
+        return self._db_user
+
+    # Gets the Isidore MySQL database host
+    # @return       The Isidore database host
+    def getDatabaseHost(self):
+        return self._db_host
+
+    # Gets the Isidore MySQL database name
+    # @return       The Isidore database user account name
+    def getDatabaseName(self):
+        return self._db_name
 
     # Gets all the decommissioned hosts in the database
     # @return   An array containing all the decommissioned hosts in

--- a/lib/src/isidore/libIsidoreCmdline.py
+++ b/lib/src/isidore/libIsidoreCmdline.py
@@ -371,6 +371,16 @@ set         modify the Isidore installation''')
         else:
             print('Invalid argument '+args[1]+'. Enter ? for help.', file=sys.stderr)
 
+    # > config set
+    def config_set(self, args):
+        if len(args) == 2:
+            self.subprompt(args, self.config_set)
+        elif args[2] == '?':
+            print('''\
+?           print this help message''')
+        else:
+            print('Invalid argument '+args[2]+'. Enter ? for help.', file=sys.stderr)
+
     # > config show
     def config_show(self, args):
         if len(args) == 2:

--- a/lib/src/isidore/libIsidoreCmdline.py
+++ b/lib/src/isidore/libIsidoreCmdline.py
@@ -98,6 +98,8 @@ quit        exit''')
         # Parse inut
         if args[0] == '?':
             self.help(args)
+        elif args[0] == 'config':
+            self.config(args)
         elif args[0] == 'create':
             self.create(args)
         elif args[0] == 'delete':
@@ -130,6 +132,7 @@ prompt.
     def help(self, args):
         print('''\
 ?           print this help message
+config      configure the Isidore installation
 create      create various objects (such as hosts and tags)
 delete      delete various objects (such as hosts and tags)
 describe    print details about various data
@@ -349,6 +352,41 @@ tags        describe all tags in the database''')
         for tag in self._isidore.getTags():
             tags[tag.getName()] = tag.getDescription()
         print(yaml.dump(tags, default_flow_style=False))
+
+    # > config
+    def config(self, args):
+        if len(args) == 1:
+            self.subprompt(args, self.config)
+        elif args[1] == '?':
+            print('''\
+?           print this help message
+show        print various data about the Isidore installation
+set         modify the Isidore installation''')
+        elif args[1] == 'show':
+            self.config_show(args)
+        elif args[1] == 'set':
+            self.config_set(args)
+        elif args[1] == 'terminal':
+            print("I have no idea what you're talking about.")
+        else:
+            print('Invalid argument '+args[1]+'. Enter ? for help.', file=sys.stderr)
+
+    # > config show
+    def config_show(self, args):
+        if len(args) == 2:
+            self.subprompt(args, self.config_show)
+        elif args[2] == '?':
+            print('''\
+?           print this help message
+connection  print all the information about the host''')
+        elif args[2] == 'connection':
+            print(yaml.dump({
+                'user': self._isidore.getDatabaseUser(),
+                'host': self._isidore.getDatabaseHost(),
+                'database': self._isidore.getDatabaseName()
+            }, default_flow_style=False))
+        else:
+            print('Invalid argument '+args[2]+'. Enter ? for help.', file=sys.stderr)
 
     # > create
     def create(self, args):

--- a/lib/src/isidore/libIsidoreCmdline.py
+++ b/lib/src/isidore/libIsidoreCmdline.py
@@ -378,13 +378,16 @@ set         modify the Isidore installation''')
         elif args[2] == '?':
             print('''\
 ?           print this help message
-connection  print all the information about the host''')
+connection  display information about SQL database connection
+version     display Isidore version information''')
         elif args[2] == 'connection':
             print(yaml.dump({
                 'user': self._isidore.getDatabaseUser(),
                 'host': self._isidore.getDatabaseHost(),
                 'database': self._isidore.getDatabaseName()
             }, default_flow_style=False))
+        elif args[2] == 'version':
+            self.version(None)
         else:
             print('Invalid argument '+args[2]+'. Enter ? for help.', file=sys.stderr)
 


### PR DESCRIPTION
Add a `config` subprompt for displaying information about the Isidore installation and configuring it. Currently it only allows for information to be displayed; configurable parameters will be forthcoming.